### PR TITLE
Fix bug where status code was not being set for linked resources

### DIFF
--- a/potion_client/resource.py
+++ b/potion_client/resource.py
@@ -41,6 +41,7 @@ class Reference(collections.Mapping):
     def _properties(self):
         if self._uri and self._status is None:
             self.__properties = self._resolve(self._client, self._uri)
+            self._status = 200
         return self.__properties
 
     @_properties.setter


### PR DESCRIPTION
For the following type of code:

```
vehicle = client.Vehicle.fetch("/api/vehicle/456")
owner = vehicle.owner
```

a `GET` request is not issued for the `owner` (which is fine), but on subsequent getting or setting of an  attribute, `owner._status` does not get set to 200. This results in a `GET` being issued on each property access or modification _and_ `save()` / `update()` not working properly (and silently failing). (Everything works fine if the `owner` is fetched directly)

I _believe_ this is a simple one-line fix, and I've added a test case for this kind of linked relationship. I'm not thrilled with the later, but believe it does at least cover the case.

@lyschoening / @joaocardoso is this the right way to address this issue in your view? Still getting familiar with the codebase here. Thanks!
