### PR TITLE
Use simplejson if available (#18)

### DIFF
--- a/potion_client/converter.py
+++ b/potion_client/converter.py
@@ -1,6 +1,11 @@
 import calendar
 from functools import partial
-from json import JSONEncoder, JSONDecoder
+
+try:
+    from simplejson import JSONEncoder, JSONDecoder
+except ImportError:
+    from json import JSONEncoder, JSONDecoder
+
 from datetime import date, datetime
 from six.moves.urllib.parse import urljoin
 import six

--- a/potion_client/links.py
+++ b/potion_client/links.py
@@ -1,4 +1,8 @@
-import json
+try:
+    import simplejson as json
+except ImportError:
+    import json
+
 import re
 
 from requests import Request


### PR DESCRIPTION
Fixes errors in #18 when some dependencies make use of simplejson while potion-client explicitly uses only the built-in json module.