### PR TITLE
fix: python3.10 collection changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.10"
 install:
   - pip install coveralls
 script: coverage run --source=potion_client setup.py test

--- a/potion_client/__init__.py
+++ b/potion_client/__init__.py
@@ -2,7 +2,12 @@ from functools import partial
 from operator import getitem, delitem, setitem
 from six.moves.urllib.parse import urlparse, urljoin
 from weakref import WeakValueDictionary
-import collections
+
+if(os.python.version > 3.6):
+    import collections.abc as collections
+else:
+    import collections
+
 import requests
 
 from potion_client.converter import PotionJSONDecoder, PotionJSONSchemaDecoder

--- a/potion_client/collection.py
+++ b/potion_client/collection.py
@@ -1,4 +1,8 @@
-import collections
+if(os.python.version > 3.6):
+    import collections.abc as collections
+else:
+    import collections
+
 from pprint import pformat
 
 from potion_client.utils import escape

--- a/potion_client/resource.py
+++ b/potion_client/resource.py
@@ -1,4 +1,8 @@
-import collections
+if(os.python.version > 3.6):
+    import collections.abc as collections
+else:
+    import collections
+
 from pprint import pformat
 
 import six

--- a/potion_client/schema.py
+++ b/potion_client/schema.py
@@ -1,4 +1,8 @@
-import collections
+if(os.python.version > 3.6):
+    import collections.abc as collections
+else:
+    import collections
+
 import re
 
 


### PR DESCRIPTION
Since the base `collections` library has changed and `Mapping`, `MutableMapping` and `Sequence` are moved to `collections.abc` a fix is needed.
